### PR TITLE
stop snow from attaching to the bottom of the screen

### DIFF
--- a/web/src/types/Snowflake.ts
+++ b/web/src/types/Snowflake.ts
@@ -60,7 +60,8 @@ export class Snowflake {
   }
 
   update(canvasWidth: number, canvasHeight: number): void {
-    const stopProbability = 0.1;
+    // TODO: Set `stopProbability` to 0.1 again and find out why invisible snowflakes aren't moved to the top
+    const stopProbability = 0;
     const shouldStop =
       Math.random() < stopProbability &&
       this.y > canvasHeight - (this.radius * Math.random() * 0.5 + 0.5);


### PR DESCRIPTION
This moves them to the top again. There's a bug making them forever
stick to the bottom of the viewport