### PR TITLE
Pick only parts of the calendar day data when showing guess page

### DIFF
--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/web/src/types/CalendarDay.ts
+++ b/web/src/types/CalendarDay.ts
@@ -1,7 +1,6 @@
 export type CalendarDay = {
   id: string;
   dayIndex: number;
-  publishedAt: string;
   audioTrackUrl: string;
   hints: Array<string> | null;
   songTitles: Array<string>;

--- a/web/src/types/CalendarDayPreview.ts
+++ b/web/src/types/CalendarDayPreview.ts
@@ -1,0 +1,8 @@
+import { CalendarDay } from "./CalendarDay";
+
+export type CalendarDayPreview = Pick<
+  CalendarDay,
+  "dayIndex" | "audioTrackUrl" | "hints" | "id"
+> & {
+  hasArtists: boolean;
+};

--- a/web/src/types/ResponseData.ts
+++ b/web/src/types/ResponseData.ts
@@ -1,3 +1,4 @@
+import { CalendarDay } from "./CalendarDay";
 import { CalendarDayStats } from "./CalendarDayStats";
 import { ErrorResponse } from "./ErrorResponse";
 
@@ -8,6 +9,7 @@ export type SuccessResponse =
   | {
       correctness: 1;
       successfulAttempts: number;
+      day: CalendarDay;
     };
 
 export type ResponseData =

--- a/web/src/types/dto/CalendarDayDTO.ts
+++ b/web/src/types/dto/CalendarDayDTO.ts
@@ -1,0 +1,16 @@
+export type CalendarDayDTO = {
+  _id: string;
+  audioTrack: {
+    _type: "file";
+    asset: {
+      _ref: string;
+      _type: "reference";
+    };
+  };
+  hints?: Array<string>;
+  dayIndex: number;
+  songTitles: Array<string>;
+  artists: Array<string>;
+  spotifyIds: Array<string>;
+  playedBy?: string;
+};

--- a/web/src/types/dto/CalendarDayPreviewDTO.ts
+++ b/web/src/types/dto/CalendarDayPreviewDTO.ts
@@ -1,0 +1,13 @@
+export type CalendarDayPreviewDTO = {
+  _id: string;
+  audioTrack: {
+    _type: "file";
+    asset: {
+      _ref: string;
+      _type: "reference";
+    };
+  };
+  hints?: Array<string>;
+  dayIndex: number;
+  artists: Array<string>;
+};

--- a/web/src/utils/firebase.utils.ts
+++ b/web/src/utils/firebase.utils.ts
@@ -5,7 +5,7 @@ import { Guess } from "../types/Guess";
 
 const CALENDAR_DAY_COLLECTION = `calendar-day-${process.env.SANITY_DATASET ?? "test"}`;
 
-export async function getDay(dayIndex: number): Promise<CalendarDayStats | ErrorResponse> {
+export async function getDayStats(dayIndex: number): Promise<CalendarDayStats | ErrorResponse> {
   const document = await firebase
     .collection(CALENDAR_DAY_COLLECTION)
     .doc(dayIndex.toString())
@@ -20,7 +20,7 @@ export async function getDay(dayIndex: number): Promise<CalendarDayStats | Error
   return data.day as CalendarDayStats;
 }
 
-export async function postDay(
+export async function postDayStats(
   dayIndex: number,
   isCorrect: boolean,
   day: CalendarDayStats,


### PR DESCRIPTION
Fixes #66

We don't need the name of the song and artist until the player has
actually won, so we'll get them as part of the win response type