### PR TITLE
purge unused Tailwind classes in production

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -2,8 +2,7 @@
 
 /** @type {import("tailwindcss/tailwind-config").TailwindConfig} */
 module.exports = {
-  purge: [],
-  // purge: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  purge: ["./src/pages/**/*.{js,ts,jsx,tsx}", "./src/components/**/*.{js,ts,jsx,tsx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
     fontFamily: {


### PR DESCRIPTION
This PR shaves off 266kBs worth of gzipped CSS (previous: 2.9MB/270kB gzipped, now: 9.6kB/3.6kB gzipped).

Before change:
![image](https://user-images.githubusercontent.com/9085189/145399494-961c9b9e-b300-4561-89eb-7bb7d90b52e0.png)

After change: 
![image](https://user-images.githubusercontent.com/9085189/145399538-fa961d80-d8ec-4a0a-b03d-a2fb88f0ebdd.png)

Optimization suggestions from web.dev/measure:
![image](https://user-images.githubusercontent.com/9085189/145400236-dea0f9ae-bff0-417c-acae-3860267dde38.png)
